### PR TITLE
Add textOnly paramater to get_links_from_email

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,7 @@ These keyword actions are available::
 
         Arguments:
             - mailNumber: is the index number of the mail to open
+            - textOnly: to use if mail is in text format
 
     Open Link from Mail:
         Find a link in an email body and open the link. Returns the links' html.

--- a/src/ImapLibrary/__init__.py
+++ b/src/ImapLibrary/__init__.py
@@ -48,14 +48,19 @@ class ImapLibrary(object):
                 time.sleep(10)
         raise AssertionError("No mail received within time")
 
-    def get_links_from_email(self, mailNumber):
+    def get_links_from_email(self, mailNumber, textOnly=False):
         '''
         Finds all links in an email body and returns them
 
         `mailNumber` is the index number of the mail to open
+
+        `textOnly` to use if the mail is in text format
         '''
         body = self.get_email_body(mailNumber)
-        return re.findall(r'href=[\'"]?([^\'" >]+)', body)
+        if not textOnly:
+            return re.findall(r'href=[\'"]?([^\'" >]+)', body)
+        else:
+            return re.findall('(https?://\\S+)', body)
 
     def open_link_from_mail(self, mailNumber, linkNumber=0):
         """


### PR DESCRIPTION
Useful when mail is format in text only
