### PR TITLE
Raise exception if imap.search returns typ != 'OK' in _check_email

### DIFF
--- a/src/ImapLibrary/__init__.py
+++ b/src/ImapLibrary/__init__.py
@@ -196,5 +196,7 @@ class ImapLibrary(object):
 
     def _check_emails(self, fromEmail, toEmail, status):
         crit = self._criteria(fromEmail, toEmail, status)
-        type, msgnums = self.imap.search(None, *crit)
+        typ, msgnums = self.imap.search(None, *crit)
+        if typ != 'OK':
+            raise Exception('imap.search error: ' + typ + ', ' + str(msgnums) + ' criterion=' + str(crit))
         return msgnums[0].split()


### PR DESCRIPTION
I had difficulty debugging errors caused by bad inputs to Wait For Mail. It's better to throw an exception when the IMAP server responds with an error.

Exception message includes returned data and input cirterion in
exception for debugging.
