### PR TITLE
Fix for multipart-mime

### DIFF
--- a/src/ImapLibrary/__init__.py
+++ b/src/ImapLibrary/__init__.py
@@ -39,7 +39,7 @@ class ImapLibrary(object):
         `timeout` sets the maximum waiting time until an error
         is raised.
         """
-        endTime = time.time() + timeout
+        endTime = time.time() + int(timeout)
         while (time.time() < endTime):
             self.mails = self._check_emails(fromEmail, toEmail, status)
             if len(self.mails) > 0:
@@ -121,7 +121,7 @@ class ImapLibrary(object):
         """
         if not self._is_walking_multipart(mailNumber):
             data = self.imap.fetch(mailNumber, '(RFC822)')[1][0][1]
-            msg = email.message_from_string(data.decode())
+            msg = email.message_from_string(data)
             self._start_walking_multipart(mailNumber, msg)
 
         try:


### PR DESCRIPTION
When using the library, I found that it was not processing multipart-mime files correctly.  

I compared it to: http://stackoverflow.com/questions/348630/how-can-i-download-all-emails-with-attachments-from-gmail

There I found that it looks like doing a 'decode()' on the output of fetch breaks email's message_from_string function.  Just removing it seems to fix the problem.

Additionally I modified the timeout in the wait_for_mail keyword.  The present version treats all actions inside it as though they were free.  This takes them into account, and decreases the number of lines of code (by 1, very exciting).
