### PR TITLE
Support for subject and body text in wait_for_mail

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,8 @@ These keyword actions are available::
         Arguments:
             - fromEmail: the email address of the sender (not required)
             - toEmail:   the email address of the receiver (not required)
+            - subject:   the subject of the email (not required)
+            - text:      some text from email body (not required)
             - status:    the status of the email (not required)
             - timeout:   the timeout how long the mailbox shall check emails
                          in seconds (defaults to 60 seconds)

--- a/src/ImapLibrary/__init__.py
+++ b/src/ImapLibrary/__init__.py
@@ -41,7 +41,7 @@ class ImapLibrary(object):
         """
         endTime = time.time() + int(timeout)
         while (time.time() < endTime):
-            self.mails = self._check_emails(fromEmail, toEmail, status)
+            self.mails = self._check_emails(fromEmail, toEmail, subject, text, status)
             if len(self.mails) > 0:
                 return self.mails[-1]
             if time.time() < endTime:

--- a/src/ImapLibrary/__init__.py
+++ b/src/ImapLibrary/__init__.py
@@ -28,8 +28,8 @@ class ImapLibrary(object):
         self.imap.select()
         self._init_walking_multipart()
 
-    def wait_for_mail(self, fromEmail=None, toEmail=None, status=None,
-                      timeout=60):
+    def wait_for_mail(self, fromEmail=None, toEmail=None, 
+                      subject=None, text=None, status=None, timeout=60):
         """
         Wait for an incoming mail from a specific sender to
         a specific mail receiver. Check the mailbox every 10
@@ -188,20 +188,24 @@ class ImapLibrary(object):
         """
         return self._mp_msg[field]
 
-    def _criteria(self, fromEmail, toEmail, status):
+    def _criteria(self, fromEmail, toEmail, subject, text, status):
         crit = []
         if fromEmail:
-            crit += ['FROM', fromEmail]
+            crit += ['FROM', '"' + fromEmail + '"']
         if toEmail:
-            crit += ['TO', toEmail]
+            crit += ['TO', '"' + toEmail + '"']
+		if subject:
+            crit += ['SUBJECT', '"' + subject + '"']
+        if text:
+            crit += ['TEXT', '"' + text + '"']
         if status:
             crit += [status]
         if not crit:
             crit = ['UNSEEN']
         return crit
 
-    def _check_emails(self, fromEmail, toEmail, status):
-        crit = self._criteria(fromEmail, toEmail, status)
+    def _check_emails(self, fromEmail, toEmail, subject, text, status):
+        crit = self._criteria(fromEmail, toEmail, subject, text, status)
         # Calling select before each search is necessary with gmail
         status, data = self.imap.select()
         if status != 'OK':

--- a/src/ImapLibrary/__init__.py
+++ b/src/ImapLibrary/__init__.py
@@ -194,7 +194,7 @@ class ImapLibrary(object):
             crit += ['FROM', '"' + fromEmail + '"']
         if toEmail:
             crit += ['TO', '"' + toEmail + '"']
-		if subject:
+	if subject:
             crit += ['SUBJECT', '"' + subject + '"']
         if text:
             crit += ['TEXT', '"' + text + '"']

--- a/src/ImapLibrary/__init__.py
+++ b/src/ImapLibrary/__init__.py
@@ -194,7 +194,7 @@ class ImapLibrary(object):
             crit += ['FROM', '"' + fromEmail + '"']
         if toEmail:
             crit += ['TO', '"' + toEmail + '"']
-	if subject:
+        if subject:
             crit += ['SUBJECT', '"' + subject + '"']
         if text:
             crit += ['TEXT', '"' + text + '"']


### PR DESCRIPTION
Added support for email subject and body text to search email. The entry point keyword `Wait For Mail` has optional arguments `subject` and `text`.